### PR TITLE
Update de-DE.json

### DIFF
--- a/de-DE.json
+++ b/de-DE.json
@@ -53,7 +53,7 @@
   "common.lap": "Runde",
   "common.laps": "Runden",
 
-  "common.rankclimbing": "Rang Klettern",
+  "common.rankclimbing": "Rang Höhenmeter",
   "common.rankendurance": "Rang Ausdauer",
   "common.ranksprint": "Rang Sprint",
   "common.ranktimetrial": "Rang Zeitfahren",


### PR DESCRIPTION
"Klettern" is a verb, but the rank is about the altitude the rider has done. 
The noun is "Höhenmeter" -> "Rang Höhenmeter" 
BTW "Klettern" means the the sport climbing, not climbing with a bike. 
